### PR TITLE
Improve Forem setup process

### DIFF
--- a/forem/scripts/rails.sh
+++ b/forem/scripts/rails.sh
@@ -3,8 +3,14 @@ set -e
 
 source scripts/services.env
 
-echo "Initializing the application"
-bin/rails app_initializer:setup
+echo "Running app_initializer:setup"
+until bin/rails app_initializer:setup
+do
+	echo "waiting before retrying app intialization"
+	sleep 60
+done
+
+echo "Running forem:setup"
 bin/rails forem:setup
 
 echo "Starting the application server"

--- a/forem/scripts/rails.sh
+++ b/forem/scripts/rails.sh
@@ -4,7 +4,8 @@ set -e
 source scripts/services.env
 
 echo "Initializing the application"
-bin/rails app_initializer:setup forem:setup
+bin/rails app_initializer:setup
+bin/rails forem:setup
 
 echo "Starting the application server"
 bin/rails s

--- a/forem/scripts/services.env
+++ b/forem/scripts/services.env
@@ -1,8 +1,20 @@
 # Interpolate environment variables
 
+if [[ -z "${APP_DOMAIN}" ]]; then
+	echo "APP_DOMAIN is unset and required."
+	exit 1
+fi
+
+if [[ -z "${SENDGRID_API_KEY}" ]]; then
+	echo "SENDGRID_API_KEY is unset and required."
+	exit 1
+fi
+
 export ELASTICSEARCH_URL="${ELASTICSEARCH_URL=http://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT}"
 
 export REDIS_URL="${REDIS_URL=redis://$REDIS_HOST:$REDIS_PORT}"
 export REDIS_SESSIONS_URL="${REDIS_SESSIONS_URL=$REDIS_URL}"
 export REDIS_SIDEKIQ_URL="${REDIS_SIDEKIQ_URL=$REDIS_URL}"
 export REDIS_RPUSH_URL="${REDIS_RPUSH_URL=$REDIS_URL}"
+
+

--- a/forem/scripts/services.env
+++ b/forem/scripts/services.env
@@ -1,11 +1,11 @@
 # Interpolate environment variables
 
-if [[ -z "${APP_DOMAIN}" ]]; then
+if [[ -z "${APP_DOMAIN}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]] ; then
 	echo "APP_DOMAIN is unset and required."
 	exit 1
 fi
 
-if [[ -z "${SENDGRID_API_KEY}" ]]; then
+if [[ -z "${SENDGRID_API_KEY}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]]; then
 	echo "SENDGRID_API_KEY is unset and required."
 	exit 1
 fi

--- a/forem/scripts/sidekiq.sh
+++ b/forem/scripts/sidekiq.sh
@@ -2,4 +2,10 @@
 set -e
 
 source scripts/services.env
+
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://$APP_DOMAIN)" != "200" ]]
+do
+	echo "waiting for Rails application"
+	sleep 10
+done
 bundle exec sidekiq -c 1


### PR DESCRIPTION
- Improve the setup process that sometimes required a manual retry upon DB setup failure
- Automate retrying `app_initializer:setup` and split out `forem:setup`
- Fail start up with message if required env vars are not set
- Make Sidekiq worker wait for Rails to come online