### PR TITLE
Add DEFAULT_EMAIL env var check

### DIFF
--- a/forem/scripts/services.env
+++ b/forem/scripts/services.env
@@ -10,6 +10,11 @@ if [[ -z "${SENDGRID_API_KEY}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}"
 	exit 1
 fi
 
+if [[ -z "${DEFAULT_EMAIL}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]]; then
+	echo "DEFAULT_EMAIL is unset and required."
+	exit 1
+fi
+
 export ELASTICSEARCH_URL="${ELASTICSEARCH_URL=http://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT}"
 
 export REDIS_URL="${REDIS_URL=redis://$REDIS_HOST:$REDIS_PORT}"

--- a/forem/scripts/services.env
+++ b/forem/scripts/services.env
@@ -1,17 +1,17 @@
 # Interpolate environment variables
 
 if [[ -z "${APP_DOMAIN}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]] ; then
-	echo "APP_DOMAIN is unset and required."
+	echo "APP_DOMAIN is unset and required. Set RENDER_FOREM_SKIP_CHECK_ENV_VARS=1 to skip this check."
 	exit 1
 fi
 
 if [[ -z "${SENDGRID_API_KEY}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]]; then
-	echo "SENDGRID_API_KEY is unset and required."
+	echo "SENDGRID_API_KEY is unset and required. Set RENDER_FOREM_SKIP_CHECK_ENV_VARS=1 to skip this check."
 	exit 1
 fi
 
 if [[ -z "${DEFAULT_EMAIL}" ]] && [[ -z "${RENDER_FOREM_SKIP_CHECK_ENV_VARS}" ]]; then
-	echo "DEFAULT_EMAIL is unset and required."
+	echo "DEFAULT_EMAIL is unset and required. Set RENDER_FOREM_SKIP_CHECK_ENV_VARS=1 to skip this check."
 	exit 1
 fi
 


### PR DESCRIPTION
- Previously, we added checks for `APP_DOMAIN` and `SENDGRID_API_KEY`
- Add in the other required env var `DEFAULT_EMAIL`
- Describe how to skip the check in the most relevant location, the error message