### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,6 +43,7 @@ services:
     dockerContext: ./forem
     dockerCommand: ./scripts/sidekiq.sh
     plan: starter plus
+    autoDeploy: false
     envVars:
       - fromGroup: rails
       - key: REDIS_HOST
@@ -76,6 +77,7 @@ services:
     dockerContext: ./forem
     dockerCommand: ./scripts/rails.sh
     plan: starter plus
+    autoDeploy: false
     disk:
       name: data
       mountPath: /opt/apps/forem/public/uploads


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>